### PR TITLE
Add MIT license and update PHP and dependencies versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,7 @@
     "name": "bit-mx/saloon-metadata",
     "description": "Adds a metadata repository to saloon request",
     "type": "library",
+    "license": "MIT",
     "autoload": {
         "psr-4": {
             "BitMx\\SaloonMetadata\\": "src/"
@@ -15,11 +16,8 @@
     ],
     "minimum-stability": "stable",
     "require": {
-        "php": "^8.2",
-        "saloonphp/saloon": "^3.0",
-        "illuminate/support": "^10.0 || ^11.0",
-        "illuminate/database": "^10.0 || ^11.0",
-        "fakerphp/faker": "^1.23"
+        "php": "^8.3",
+        "saloonphp/saloon": "^3.0"
     },
     "require-dev": {
         "laravel/pint": "^1.15",


### PR DESCRIPTION
The MIT license was added to the composer.json file. Updated the PHP requirement to ^8.3 and removed unnecessary dependencies to streamline the package requirements.
