### PR TITLE
Refactor namespaces and add PHPStan configuration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,11 +21,15 @@
     },
     "require-dev": {
         "laravel/pint": "^1.15",
-        "pestphp/pest": "^2.34"
+        "pestphp/pest": "^2.34",
+        "phpstan/phpstan": "^2.0",
+        "phpstan/extension-installer": "^1.4.0",
+        "tomasvotruba/type-coverage": "^2.0.2"
     },
     "config": {
         "allow-plugins": {
-            "pestphp/pest-plugin": true
+            "pestphp/pest-plugin": true,
+            "phpstan/extension-installer": true
         }
     }
 }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,6 @@
+parameters:
+    ignoreErrors:
+        -
+            identifier:  trait.unused
+            path: src/Traits/HasMetadata.php
+

--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -1,0 +1,12 @@
+includes:
+    - phpstan-baseline.neon
+
+parameters:
+    level: 7
+    paths:
+        - src
+
+    type_coverage:
+        return: 100
+        param: 100
+        property: 100

--- a/src/Contracts/Metadatable.php
+++ b/src/Contracts/Metadatable.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Libs\Saloon\Contracts;
+namespace BitMx\SaloonMetadata\Contracts;
 
 use Saloon\Repositories\Body\ArrayBodyRepository;
 

--- a/src/Exceptions/MetadataException.php
+++ b/src/Exceptions/MetadataException.php
@@ -1,5 +1,5 @@
 <?php
 
-namespace App\Libs\Saloon\Exceptions;
+namespace BitMx\SaloonMetadata\Exceptions;
 
 class MetadataException extends \Exception {}

--- a/src/Traits/HasMetadata.php
+++ b/src/Traits/HasMetadata.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace App\Libs\Saloon\Traits;
+namespace BitMx\SaloonMetadata\Traits;
 
-use App\Libs\Saloon\Contracts\Metadatable;
-use App\Libs\Saloon\Exceptions\MetadataException;
+use BitMx\SaloonMetadata\Contracts\Metadatable;
+use BitMx\SaloonMetadata\Exceptions\MetadataException;
 use Saloon\Http\PendingRequest;
 use Saloon\Repositories\Body\ArrayBodyRepository;
 


### PR DESCRIPTION
Updated namespaces from `App\Libs\Saloon` to `BitMx\SaloonMetadata` for better project organization. Introduced PHPStan with a baseline, type coverage settings, and additional composer dependencies to enhance code quality and static analysis.
